### PR TITLE
Request authorization token at each call

### DIFF
--- a/plugins/osx/README.md
+++ b/plugins/osx/README.md
@@ -9,12 +9,8 @@ To start using it, add the `osx` plugin to your plugins array in `~/.zshrc`:
 ```zsh
 plugins=(... osx)
 ```
-
 Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
-
-
 ## Commands
-
 | Command         | Description                                      |
 | :-------------- | :----------------------------------------------- |
 | `tab`           | Open the current directory in a new tab          |
@@ -31,3 +27,12 @@ Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
 | `hidefiles`     | Hide the hidden files                            |
 | `itunes`        | Control iTunes. User `itunes -h` for usage details |
 | `spotify`       | Control Spotify and search by artist, album, track and etc.|
+
+
+Note: Spotify command requires OAUTH token for searching music. It can be generated
+from [Spotify Web API Console](https://developer.spotify.com/web-api/console/get-search-item/).
+Do not make your Spotify OAUTH token public.
+
+```zsh
+export SPOTIFY_OAUTH_TOKEN="..."
+```

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -355,6 +355,7 @@ function spotify() {
           len=${#array[@]};
           SPOTIFY_SEARCH_API="https://api.spotify.com/v1/search"
           SPOTIFY_PLAY_URI="";
+          SPOTIFY_AUTH="Authorization: Bearer $SPOTIFY_OAUTH_TOKEN"
 
           searchAndPlay() {
             type="$1"
@@ -363,7 +364,7 @@ function spotify() {
             cecho "Searching ${type}s for: $Q";
 
             SPOTIFY_PLAY_URI=$( \
-              curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=$type&limit=1&offset=0" -H "Accept: application/json" \
+              curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=$type&limit=1&offset=0" -H "Accept: application/json" -H $SPOTIFY_AUTH \
               | grep -E -o "spotify:$type:[a-zA-Z0-9]+" -m 1
               )
           }
@@ -376,7 +377,7 @@ function spotify() {
               cecho "Searching playlists for: $Q";
 
               results=$( \
-                curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" \
+                curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" -H $SPOTIFY_AUTH \
                 | grep -E -o "spotify:user:[a-zA-Z0-9_]+:playlist:[a-zA-Z0-9]+" -m 10 \
                 )
 


### PR DESCRIPTION
Any authorization token expires after an hour, so relying on an environmental variable will not work. The ``spotify()`` function needs to renew the token every time it is called to ensure it works.

Morever, the user must

1. Get a ``client_id`` and a ``client_secret_key`` for a phony app that you create with your account at Spotify's developer website. The id and the key are needed to generate the authorization token.
2. Create a base64 (strict) encoded call token in the form ``base64_encode("$CLIENT_ID:$SECRET_KEY")``. 
3. export the encoding as ``SPOTIFY_CALL_TOKEN``
